### PR TITLE
[b63] improve l1d example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -41,7 +41,7 @@ bm_custom:
 bm_l1d_miss:
 	mkdir -p _build/
 	c++ -Wall -Wno-unused-function l1d_miss.cpp -I. -O3 -o _build/bm_l1d_miss -std=c++17
-	./_build/bm_l1d_miss -i -c lpe:L1-dcache-load-misses
+	./_build/bm_l1d_miss -i -c lpe:L1-dcache-load-misses,time
 
 bm_raw:
 	mkdir -p _build/

--- a/examples/l1d_miss.cpp
+++ b/examples/l1d_miss.cpp
@@ -36,7 +36,7 @@ B63_BASELINE(sequential, n) {
   int32_t res = 0;
   for (size_t i = 0; i < n; i++) {
     for (size_t j = 0; j < kSize; j++) {
-      res += v[j];
+      res += v[v[j] & kMask];
     }
   }
 
@@ -61,6 +61,6 @@ B63_BENCHMARK(random, n) {
 
 int main(int argc, char **argv) {
   srand(time(0));
-  B63_RUN_WITH("lpe:L1-dcache-load-misses", argc, argv);
+  B63_RUN_WITH("lpe:L1-dcache-load-misses,time", argc, argv);
   return 0;
 }


### PR DESCRIPTION
Old version had more differences rather than just 'random access'. Due to direct vs indirect access difference, It was, for example, trivial to vectorize first loop, but not possible to
vectorize second.