### PR TITLE
Make it compatible with toolchains that has not clock_gettime support…

### DIFF
--- a/src/counters/time.h
+++ b/src/counters/time.h
@@ -16,17 +16,28 @@
 
 #ifndef _B63_COUNTERS_TIME_H_
 #define _B63_COUNTERS_TIME_H_
-
+#ifdef NO_GET_TIME_SUPPORTED
+#include <sys/time.h>
+#else
 #include <time.h>
-
+#endif
 #include "../counter.h"
 
 /* default counter returning time in nanoseconds */
 B63_COUNTER(time) {
+#ifdef NO_GET_TIME_SUPPORTED
+  struct timeval tv;
+
+  if (gettimeofday (&tv, NULL) == 0)
+    return (uint64_t) (tv.tv_sec * 1000000 + tv.tv_usec) * 1000;
+  else
+    return 0;
+#else
   struct timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
   int64_t res = 1000000000LL * (int64_t)t.tv_sec + t.tv_nsec;
   return res;
+#endif
 }
 
 #endif

--- a/src/utils/timer.h
+++ b/src/utils/timer.h
@@ -16,8 +16,11 @@
 
 #ifndef _B63_UTILS_TIME_H_
 #define _B63_UTILS_TIME_H_
-
+#ifdef NO_GET_TIME_SUPPORTED
+#include <sys/time.h>
+#else
 #include <time.h>
+#endif
 
 /*
  * This is used NOT for benchmarking itself, but to track
@@ -25,10 +28,19 @@
  * See src/run.h -> b63_run_benchmark implementation for usage;
  */
 int64_t b63_now_ms() {
+#ifdef NO_GET_TIME_SUPPORTED
+  struct timeval tv;
+
+  if (gettimeofday(&tv, NULL) == 0)
+    return (uint64_t) (tv.tv_sec * 1000000 + tv.tv_usec) / 1000;
+  else
+    return 0;
+#else
   struct timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
   int64_t res = 1000 * t.tv_sec + t.tv_nsec / 1000000;
   return res;
+#endif
 }
 
 #endif


### PR DESCRIPTION
This solution can be chosen via a flag and has a minimum loss of precision from nanoseconds to microseconds.