### PR TITLE
Fixed next_seed signed integer overflow

### DIFF
--- a/include/b63/run.h
+++ b/include/b63/run.h
@@ -90,7 +90,7 @@ static void b63_benchmark_run(b63_benchmark *b, b63_counter *c,
       b->failed = 1;
       break;
     }
-    next_seed = 134775853LL * next_seed + 1;
+    next_seed = 134775853ULL * next_seed + 1;
 
     double baseline_rate = 0.0;
     if (baseline_result != NULL) {
@@ -234,5 +234,5 @@ static void b63_suspension_done(b63_suspension *s) {
  * but it's important to be able to make sure benchmark produced expected result
  * if applicable
  */
-#define B63_ASSERT(c) if (!(c)) { b63run->fail = 1; } 
+#define B63_ASSERT(c) if (!(c)) { b63run->fail = 1; }
 


### PR DESCRIPTION
Fixed undefined behavior caused by signed integer overflow. It was found by running the example code from README with UB sanitizer enabled. 
```
b63/include/b63/run.h:93:29: runtime error: signed integer overflow: 140731588872112 * 134775853 cannot be represented in type 'long int'
```
An optimizing compiler might break the code with signed overflow if it can detect the possibility of it happening at compile time. Even if this has not been the case yet, any update to the given compiler might introduce breakage. In fact, the RNG could be broken (bad distribution or something) right now with some compilers for all I know, I didn't bother to investigate further.

If this seems pedantic, a signed integer overflow might trap on some targets. Even if the target CPU architecture wraps and doesn't trap (like x86_64), UB sanitizer and compilers can be [configured to trap](https://www.gnu.org/software/c-intro-and-ref/manual/html_node/Signed-Overflow.html), which is relatively common for debugging and to generate implicit assertions. I know I do this.

By changing the literal postfix to `ULL`, `next_seed` will also be promoted to `unsigned long long`, so the overflow caused by multiplication will have well defined wrapping behavior. Note that assigning the result back to `next_seed` in case of it being larger than `INT64_MAX` (which we know will happen since we found overflow too) relies on implementation defined behavior. You could fix this by type punning:
```c
uint64_t wrapping_next_seed = 134775853LL * next_seed + 1;
memcpy(&next_seed, &wrapping_next_seed, sizeof next_seed);
```
but I think that this might be overly pedantic since technically not UB and most common implementations wrap. However, if absolute correctness is desired, then you should do it.

IMHO `next_seed` should've been `uint64_t` to begin with, but I noticed that the codebase uses a lot of signed integers for some reason so I kept the type intact for consistency. Anyway there may be a reason why it was signed that I'm not aware of.

Seems like my text editor also automatically removed a trailing space too. Sorry for the overly verbose description for basically a single character change, I got a little carried away here.